### PR TITLE
Unpin python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "platformdirs>=4.3.6",
 ]
 readme = "README.md"
-requires-python = ">= 3.12, <3.13"
+requires-python = ">=3.9"
 
 [build-system]
 requires = ["hatchling==1.26.3"]


### PR DESCRIPTION
Unless there is a very good reason, all the advice I have read is to keep your pins as loose as possible. This article provides a very deep dive into it: https://iscinumpy.dev/post/bound-version-constraints/