### PR TITLE
Remove CVs covered by CF conventions

### DIFF
--- a/src/esgvoc/api/data_descriptors/conventions.py
+++ b/src/esgvoc/api/data_descriptors/conventions.py
@@ -1,6 +1,0 @@
-from esgvoc.api.data_descriptors.data_descriptor import PlainTermDataDescriptor
-
-
-class Convention(PlainTermDataDescriptor):
-    description: str
-    label: str


### PR DESCRIPTION
The CF conventions cover these data descriptors so it's not up to us/esgvoc to define their standards. As a result, I would just drop them, let them be someone who is trying to reproduce/match CF conventions' problem instead (like the QAQC team 😆 )