### PR TITLE
Integration

### DIFF
--- a/src/esgvoc/__init__.py
+++ b/src/esgvoc/__init__.py
@@ -1,3 +1,3 @@
 import esgvoc.core.logging_handler  # noqa
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"

--- a/src/esgvoc/admin/builder.py
+++ b/src/esgvoc/admin/builder.py
@@ -48,6 +48,7 @@ class BuildResult:
     esgvoc_version: str
     checksum_sha256: str
     size_bytes: int
+    release_notes: Optional[str] = None
 
     def summary(self) -> str:
         mb = self.size_bytes / 1_048_576
@@ -279,7 +280,9 @@ class DBBuilder:
             shutil.copy2(str(universe_db), str(output_path))
 
             esgvoc_version = getattr(esgvoc, "__version__", "unknown")
-            cv_ver = universe_version or "standalone"
+            # Load manifest from universe repo if present (provides release_notes)
+            universe_manifest = Manifest.load_or_default(universe_path, project_id="universe")
+            cv_ver = universe_version or universe_manifest.cv_version or "standalone"
             metadata = {
                 "project_id": "universe",
                 "cv_version": cv_ver,
@@ -288,7 +291,8 @@ class DBBuilder:
                 "universe_commit_sha": universe_sha or "unknown",
                 "build_date": datetime.now(timezone.utc).isoformat(),
                 "esgvoc_version": esgvoc_version,
-                "esgvoc_min_version": esgvoc_min_version or esgvoc_version,
+                "esgvoc_min_version": esgvoc_min_version or universe_manifest.esgvoc.min_version or esgvoc_version,
+                "release_notes": universe_manifest.release_notes or "",
             }
             self._embed_metadata(output_path, metadata)
             checksum = _sha256(output_path)
@@ -305,6 +309,7 @@ class DBBuilder:
                 esgvoc_version=getattr(esgvoc, "__version__", "unknown"),
                 checksum_sha256=checksum,
                 size_bytes=output_path.stat().st_size,
+                release_notes=universe_manifest.release_notes,
             )
 
     # ------------------------------------------------------------------
@@ -371,6 +376,7 @@ class DBBuilder:
             "build_date": build_date.isoformat(),
             "esgvoc_version": esgvoc_version,
             "esgvoc_min_version": manifest.esgvoc.min_version or esgvoc_version,
+            "release_notes": manifest.release_notes or "",
         }
         self._embed_metadata(output_path, metadata)
 
@@ -389,6 +395,7 @@ class DBBuilder:
             esgvoc_version=esgvoc_version,
             checksum_sha256=checksum,
             size_bytes=output_path.stat().st_size,
+            release_notes=manifest.release_notes,
         )
 
     def _build_universe_db(self, universe_path: Path, universe_db: Path, universe_sha: Optional[str]) -> None:

--- a/src/esgvoc/api/project_specs.py
+++ b/src/esgvoc/api/project_specs.py
@@ -67,6 +67,11 @@ class AttributeProperty(BaseModel):
         validation_alias=AliasChoices("attr_field_name", "field_name"),
     )
     "The name of the attribute field."
+
+    @property
+    def field_name(self) -> str | None:
+        """Backward-compatibility alias for attr_field_name."""
+        return self.attr_field_name
     attr_field_na_value: str | None = Field(
         default=None,
         validation_alias=AliasChoices("attr_field_na_value", "default_value"),

--- a/src/esgvoc/apps/jsg/json_schema_generator.py
+++ b/src/esgvoc/apps/jsg/json_schema_generator.py
@@ -288,6 +288,8 @@ class CatalogPropertiesJsonTranslator:
         else:
             field_value["type"] = catalog_property.catalog_field_value_type
             root_property = field_value
+            if "string" in catalog_property.catalog_field_value_type and catalog_property.source_collection is None:
+                root_property["maxLength"] = 1064
 
         if (property_key is not None) and (property_value is not None):
             root_property[property_key] = property_value

--- a/src/esgvoc/cli/use.py
+++ b/src/esgvoc/cli/use.py
@@ -26,7 +26,7 @@ console = Console()
 
 # Patterns that indicate a registry-sourced name (auto-download eligible)
 _REGISTRY_PATTERNS = re.compile(
-    r"^(v\d+\.\d+\.\d+.*|latest|dev-latest)$"
+    r"^(v?\d+\.\d+\.\d+.*|latest|dev-latest)$"
 )
 
 
@@ -44,11 +44,11 @@ def _parse_project_name(spec: str) -> tuple[str, Optional[str]]:
 
 @app.command()
 def use(
-    spec: str = typer.Argument(
+    specs: list[str] = typer.Argument(
         ...,
         help=(
-            "Project and version, e.g. 'cmip7@v2.1.0', 'cmip7@latest', "
-            "or 'cmip7@my-experiment'. Omit name to activate newest installed."
+            "One or more project specs, e.g. 'cmip7@1.1.0', 'universe@latest', "
+            "'cmip7@my-experiment'. Omit version to activate newest installed."
         ),
     ),
     prerelease: bool = typer.Option(
@@ -56,12 +56,31 @@ def use(
         help="When using 'latest', include pre-release versions.",
     ),
 ):
-    """Activate a project version, downloading from the registry if needed."""
+    """Activate one or more project versions, downloading from the registry if needed."""
+    from esgvoc.core.service.user_state import UserState
+
+    state = UserState.load()
+    failed: list[str] = []
+
+    for spec in specs:
+        try:
+            _use_one(spec, prerelease, state)
+        except typer.Exit as e:
+            failed.append(spec)
+            if len(specs) == 1:
+                raise
+            console.print(f"[red]Failed:[/red] {spec} (exit {e.exit_code}), continuing…")
+
+    if failed:
+        console.print(f"\n[red]Failed specs:[/red] {', '.join(failed)}")
+        raise typer.Exit(1)
+
+
+def _use_one(spec: str, prerelease: bool, state) -> None:
+    """Activate a single project spec."""
     from esgvoc.core.service.user_state import UserState
 
     project_id, name = _parse_project_name(spec)
-
-    state = UserState.load()
 
     # ---------------------------------------------------------------
     # Case 1: no name given → activate newest already-installed version
@@ -117,7 +136,7 @@ def use(
             raise typer.Exit(2) from None
 
         # Use the resolved concrete version as the name on disk
-        # (e.g. "latest" resolves to "v2.1.0")
+        # (e.g. "latest" resolves to "1.1.0")
         name = snapshot.version
         target = UserState.db_path(project_id, name)
 

--- a/tests/admin_build_db/test_builder.py
+++ b/tests/admin_build_db/test_builder.py
@@ -562,7 +562,7 @@ class TestBuildUniverseOrchestration:
                 universe_ref="main",
                 output_path=output,
             )
-        assert result.cv_version == "standalone"
+        assert result.cv_version == "0.0.0-unknown"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

  Added

  - Allow multiple inputs for the esgvoc use command.
  - CV manifest feature: builder reads esgvoc_manifest.yaml and embeds release_notes into the _esgvoc_metadata table of the built DB.

  Fixed

  - project_spec: Added legacy field_name alias for attr_field_name (for esgprep/qaqc compatibility until their next release).
  - JSG: Added maxLength constraint to free-text string properties (PR #226).