### PR TITLE
Integration

### DIFF
--- a/src/esgvoc/__init__.py
+++ b/src/esgvoc/__init__.py
@@ -1,3 +1,3 @@
 import esgvoc.core.logging_handler  # noqa
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"

--- a/src/esgvoc/admin/builder.py
+++ b/src/esgvoc/admin/builder.py
@@ -274,7 +274,7 @@ class DBBuilder:
 
             universe_db = tmp / "universe.db"
             self._log("Building universe DB…")
-            self._build_universe_db(universe_path, universe_db, universe_sha)
+            ingestion_errors = self._build_universe_db(universe_path, universe_db, universe_sha)
 
             output_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(str(universe_db), str(output_path))
@@ -293,6 +293,7 @@ class DBBuilder:
                 "esgvoc_version": esgvoc_version,
                 "esgvoc_min_version": esgvoc_min_version or universe_manifest.esgvoc.min_version or esgvoc_version,
                 "release_notes": universe_manifest.release_notes or "",
+                "ingestion_errors": str(ingestion_errors),
             }
             self._embed_metadata(output_path, metadata)
             checksum = _sha256(output_path)
@@ -348,17 +349,18 @@ class DBBuilder:
 
         # 1. Build universe
         self._log("Building universe DB…")
-        self._build_universe_db(universe_path, universe_db, universe_sha)
+        universe_errors = self._build_universe_db(universe_path, universe_db, universe_sha)
 
         # 2. Build project (with universe path injected into service context)
         self._log(f"Building project DB ({manifest.project.id})…")
-        self._build_project_db(
+        project_errors = self._build_project_db(
             project_path=project_path,
             universe_path=universe_path,
             universe_db=universe_db,
             project_db=project_db,
             project_sha=project_sha,
         )
+        ingestion_errors = universe_errors + project_errors
 
         # 3. Copy project DB to output
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -377,6 +379,7 @@ class DBBuilder:
             "esgvoc_version": esgvoc_version,
             "esgvoc_min_version": manifest.esgvoc.min_version or esgvoc_version,
             "release_notes": manifest.release_notes or "",
+            "ingestion_errors": str(ingestion_errors),
         }
         self._embed_metadata(output_path, metadata)
 
@@ -398,12 +401,11 @@ class DBBuilder:
             release_notes=manifest.release_notes,
         )
 
-    def _build_universe_db(self, universe_path: Path, universe_db: Path, universe_sha: Optional[str]) -> None:
+    def _build_universe_db(self, universe_path: Path, universe_db: Path, universe_sha: Optional[str]) -> int:
         from esgvoc.core.db.connection import DBConnection
         from esgvoc.core.db.models.universe import universe_create_db
         from esgvoc.core.db.universe_ingestion import ingest_metadata_universe, ingest_universe
 
-        print(self)
         if universe_db.exists():
             universe_db.unlink()
         universe_db.parent.mkdir(parents=True, exist_ok=True)
@@ -413,11 +415,13 @@ class DBBuilder:
         ingest_metadata_universe(conn, universe_sha or "unknown")
 
         tracker = MissingLinksTracker() if self.fail_on_missing_links else None
-        ingest_universe(universe_path, universe_db, tracker)
+        errors = ingest_universe(universe_path, universe_db, tracker)
 
         if tracker and tracker.has_missing_links():
             tracker.print_summary()
             tracker.check_and_raise()
+
+        return errors
 
     def _build_project_db(
         self,
@@ -426,7 +430,7 @@ class DBBuilder:
         universe_db: Path,
         project_db: Path,
         project_sha: Optional[str],
-    ) -> None:
+    ) -> int:
         from esgvoc.core.db.models.project import project_create_db
         from esgvoc.core.db.project_ingestion import ingest_project
 
@@ -442,11 +446,13 @@ class DBBuilder:
         # is no prior row — which is what the API expects (SQLITE_FIRST_PK = 1).
 
         tracker = MissingLinksTracker() if self.fail_on_missing_links else None
-        ingest_project(project_path, project_db, project_sha or "unknown", str(universe_path), tracker)
+        errors = ingest_project(project_path, project_db, project_sha or "unknown", str(universe_path), tracker)
 
         if tracker and tracker.has_missing_links():
             tracker.print_summary()
             tracker.check_and_raise()
+
+        return errors
 
     # ------------------------------------------------------------------
     # Metadata

--- a/src/esgvoc/admin/validator.py
+++ b/src/esgvoc/admin/validator.py
@@ -86,7 +86,17 @@ class DBValidator:
             val = metadata.get(key, "")
             result.add(f"metadata.{key}", bool(val), val or "missing")
 
-        # 5. Core tables have data — checked based on DB type
+        # 5. Ingestion errors — if tracked, must be zero
+        ingestion_errors = metadata.get("ingestion_errors", "")
+        if ingestion_errors:
+            error_count = int(ingestion_errors)
+            result.add(
+                "ingestion_errors",
+                error_count == 0,
+                f"{error_count} term(s) failed to ingest" if error_count > 0 else "0",
+            )
+
+        # 6. Core tables have data — checked based on DB type
         is_universe = metadata.get("project_id", "") == "universe"
         if is_universe:
             core_tables = [
@@ -113,6 +123,12 @@ class DBValidator:
                 self._check_sample_query(conn, result)
 
         conn.close()
+
+        # 7. API term instantiation — try to instantiate every term through the public API
+        project_id = metadata.get("project_id", "")
+        if project_id:
+            self._check_all_terms_via_api(db_path, project_id, result, is_universe=is_universe)
+
         return result
 
     def validate_schema(self, project_path: Path) -> ValidationResult:
@@ -177,6 +193,62 @@ class DBValidator:
                 result.add(f"FTS index {table}", count > 0, f"{count} rows")
             except Exception as e:
                 result.add(f"FTS index {table}", False, str(e))
+
+    @staticmethod
+    def _check_all_terms_via_api(
+        db_path: Path, project_id: str, result: ValidationResult, *, is_universe: bool = False
+    ) -> None:
+        """Temporarily install the DB and try to instantiate every term via the public API."""
+        import shutil
+
+        from esgvoc.core.service.user_state import UserState
+
+        _VALIDATE_VERSION = "_validate_temp"
+
+        state = UserState.load()
+        previous_active = state.get_active(project_id)
+
+        target = UserState.db_path(project_id, _VALIDATE_VERSION)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(db_path), str(target))
+        state.set_active(project_id, _VALIDATE_VERSION, source="local")
+
+        try:
+            import esgvoc.api as ev
+
+            if is_universe:
+                try:
+                    terms = ev.get_all_terms_in_universe()
+                    result.add("API term instantiation", True, f"{len(terms)} universe terms OK")
+                except Exception as exc:
+                    result.add("API term instantiation", False, str(exc))
+            else:
+                collections = ev.get_all_collections_in_project(project_id)
+                total = 0
+                failed_collections: list[str] = []
+                for coll_name in collections:
+                    try:
+                        terms = ev.get_all_terms_in_collection(project_id, coll_name)
+                        total += len(terms)
+                    except Exception as exc:
+                        failed_collections.append(f"{coll_name}: {exc}")
+
+                if failed_collections:
+                    msg = f"{len(failed_collections)} collection(s) failed: " + "; ".join(failed_collections[:3])
+                    result.add("API term instantiation", False, msg)
+                else:
+                    result.add("API term instantiation", True, f"{total} terms across {len(collections)} collections OK")
+        finally:
+            # Restore previous state
+            if previous_active:
+                state.set_active(project_id, previous_active, source="local")
+            else:
+                state.remove_active(project_id)
+            target.unlink(missing_ok=True)
+            try:
+                target.parent.rmdir()
+            except OSError:
+                pass
 
     @staticmethod
     def _check_sample_query(conn: sqlite3.Connection, result: ValidationResult) -> None:

--- a/src/esgvoc/api/project_specs.py
+++ b/src/esgvoc/api/project_specs.py
@@ -56,9 +56,7 @@ class AttributeProperty(BaseModel):
     "The project collection that originated the property."
     is_required: bool
     "Specifies if the attribute must be present in the NetCDF file."
-    attr_field_value_type: str = Field(
-        validation_alias=AliasChoices("attr_field_value_type", "value_type")
-    )
+    attr_field_value_type: str = Field(validation_alias=AliasChoices("attr_field_value_type", "value_type"))
     "The type of the attribute value."
     specific_key: str | None = None
     "Specifies a specific key in the collection."
@@ -72,6 +70,7 @@ class AttributeProperty(BaseModel):
     def field_name(self) -> str | None:
         """Backward-compatibility alias for attr_field_name."""
         return self.attr_field_name
+
     attr_field_na_value: str | None = Field(
         default=None,
         validation_alias=AliasChoices("attr_field_na_value", "default_value"),

--- a/src/esgvoc/apps/jsg/json_schema_generator.py
+++ b/src/esgvoc/apps/jsg/json_schema_generator.py
@@ -382,6 +382,27 @@ def generate_json_schema(project_id: str) -> dict:
     else:
         raise EsgvocNotFoundError(f"unknown project '{project_id}'")
 
+def get_schema_version(project_id: str) -> str:
+    """
+    Return the catalog schema version for the given project.
+
+    :param project_id: The id of the given project.
+    :type project_id: str
+    :returns: The catalog schema version string.
+    :rtype: str
+    :raises EsgvocNotFoundError: If the project or its catalog specs are not found.
+    """
+    project_specs = projects.get_project(project_id)
+    if project_specs is not None:
+        catalog_specs = project_specs.catalog_specs
+        if catalog_specs is not None:
+            return catalog_specs.version
+        else:
+            raise EsgvocNotFoundError(
+                f"catalog properties for the project '{project_id}' are missing"
+            )
+    else:
+        raise EsgvocNotFoundError(f"unknown project '{project_id}'")
 
 def pretty_print_json_node(obj: dict) -> str:
     """

--- a/src/esgvoc/cli/test_cv.py
+++ b/src/esgvoc/cli/test_cv.py
@@ -257,41 +257,24 @@ def _api_smoke_test(project_id: str) -> bool:
         _print_api_summary(errors)
         return False
 
-    # 2. Spot-check terms in the first few collections
+    # 2. Instantiate ALL terms in ALL collections (full API validation)
     table = Table(title=f"Collection summary — {project_id}")
     table.add_column("Collection", style="cyan")
     table.add_column("Terms", justify="right")
     table.add_column("Status")
 
-    spot_limit = 5  # Check up to this many collections in detail
-    for coll_name in collections[:spot_limit]:
+    total_terms = 0
+    for coll_name in collections:
         try:
             terms = ev.get_all_terms_in_collection(project_id, coll_name)
+            total_terms += len(terms)
             table.add_row(coll_name, str(len(terms)), "[green]OK[/green]")
         except Exception as exc:
             table.add_row(coll_name, "?", f"[red]ERROR: {exc}[/red]")
             errors.append(f"get_all_terms_in_collection({coll_name!r}): {exc}")
 
-    if len(collections) > spot_limit:
-        table.add_row(f"… {len(collections) - spot_limit} more", "", "[dim]not spot-checked[/dim]")
-
     console.print(table)
-
-    # 3. Instantiate one term from the first collection (if any)
-    if collections:
-        first_coll = collections[0]
-        try:
-            terms = ev.get_all_terms_in_collection(project_id, first_coll)
-            if terms:
-                term = terms[0]
-                console.print(
-                    f"  [green]✓[/green] Instantiated term: [cyan]{first_coll}/{term.id}[/cyan] (type={term.type})"
-                )
-            else:
-                console.print(f"  [yellow]⚠[/yellow] Collection '{first_coll}' is empty")
-        except Exception as exc:
-            errors.append(f"instantiate first term in {first_coll!r}: {exc}")
-            console.print(f"  [red]✗[/red] Instantiate term: {exc}")
+    console.print(f"  [green]✓[/green] {total_terms} terms instantiated across {len(collections)} collections")
 
     _print_api_summary(errors)
     return len(errors) == 0

--- a/src/esgvoc/core/db/project_ingestion.py
+++ b/src/esgvoc/core/db/project_ingestion.py
@@ -58,7 +58,7 @@ def ingest_collection(
     project_db_session,
     universe_local_path: str,
     missing_links_tracker: Optional["MissingLinksTracker"] = None,
-) -> None:
+) -> int:
     from esgvoc.core.service.resolver_config import ResolverConfig
 
     collection_id = collection_dir_path.name
@@ -80,6 +80,7 @@ def ingest_collection(
     )  # We ll know it only when we ll add a term
     # (hypothesis all term have the same kind in a collection) # noqa E116
     term_kind_collection = None
+    error_count = 0
 
     for term_file_path in collection_dir_path.iterdir():
         _LOGGER.debug(f"found term path : {term_file_path}")
@@ -136,6 +137,7 @@ def ingest_collection(
                     f"   Error Message: {str(e)}\n"
                     f"   Full Traceback:\n{traceback.format_exc()}"
                 )
+                error_count += 1
                 continue
             try:
                 term = PTerm(
@@ -155,6 +157,7 @@ def ingest_collection(
                     f"   Error Message: {str(e)}\n"
                     f"   Full Traceback:\n{traceback.format_exc()}"
                 )
+                error_count += 1
                 continue
     # Report ingestion results for this collection
     json_file_count = len([f for f in collection_dir_path.glob("*.json")])
@@ -178,6 +181,7 @@ def ingest_collection(
         )
         collection.term_kind = TermKind.PLAIN
     project_db_session.add(collection)
+    return error_count
 
 
 def ingest_project(
@@ -186,7 +190,7 @@ def ingest_project(
     git_hash: str,
     universe_local_path: str,
     missing_links_tracker: Optional["MissingLinksTracker"] = None,
-):
+) -> int:
     try:
         project_connection = db.DBConnection(project_db_file_path)
     except Exception as e:
@@ -221,12 +225,14 @@ def ingest_project(
         project = Project(id=project_id, specs=project_specs, git_hash=git_hash)
         project_db_session.add(project)
 
+        total_errors = 0
         for collection_dir_path in project_dir_path.iterdir():
             # TODO maybe put that in settings
             if collection_dir_path.is_dir() and (collection_dir_path / "000_context.jsonld").exists():
                 _LOGGER.debug(f"found collection dir : {collection_dir_path}")
                 try:
-                    ingest_collection(collection_dir_path, project, project_db_session, universe_local_path, missing_links_tracker)
+                    errors = ingest_collection(collection_dir_path, project, project_db_session, universe_local_path, missing_links_tracker)
+                    total_errors += errors
                 except Exception as e:
                     msg = f"unexpected error while ingesting collection {collection_dir_path}"
                     _LOGGER.fatal(msg)
@@ -258,3 +264,10 @@ def ingest_project(
             _LOGGER.fatal(msg)
             raise EsgvocDbError(msg) from e
         project_db_session.commit()
+
+        if total_errors > 0:
+            _LOGGER.error(
+                f"❌ {total_errors} term(s) failed to ingest in project '{project_id}'"
+            )
+
+        return total_errors

--- a/src/esgvoc/core/db/universe_ingestion.py
+++ b/src/esgvoc/core/db/universe_ingestion.py
@@ -35,7 +35,7 @@ def ingest_universe(
     universe_repo_dir_path: Path,
     universe_db_file_path: Path,
     missing_links_tracker: Optional["MissingLinksTracker"] = None,
-) -> None:
+) -> int:
     try:
         connection = db.DBConnection(universe_db_file_path)
     except Exception as e:
@@ -43,12 +43,14 @@ def ingest_universe(
         _LOGGER.fatal(msg)
         raise IOError(msg) from e
 
+    total_errors = 0
     for data_descriptor_dir_path in universe_repo_dir_path.iterdir():
         if (
             data_descriptor_dir_path.is_dir() and (data_descriptor_dir_path / "000_context.jsonld").exists()
         ):  # TODO may be put that in setting
             try:
-                ingest_data_descriptor(data_descriptor_dir_path, connection, str(universe_repo_dir_path), missing_links_tracker)
+                errors = ingest_data_descriptor(data_descriptor_dir_path, connection, str(universe_repo_dir_path), missing_links_tracker)
+                total_errors += errors
             except Exception as e:
                 msg = f"unexpected error while processing data descriptor {data_descriptor_dir_path}"
                 _LOGGER.fatal(msg)
@@ -80,6 +82,13 @@ def ingest_universe(
             raise EsgvocDbError(msg) from e
         session.commit()
 
+    if total_errors > 0:
+        _LOGGER.error(
+            f"❌ {total_errors} term(s) failed to ingest in universe"
+        )
+
+    return total_errors
+
 
 def ingest_metadata_universe(connection, git_hash):
     with connection.create_session() as session:
@@ -93,7 +102,7 @@ def ingest_data_descriptor(
     connection: db.DBConnection,
     universe_local_path: str,
     missing_links_tracker: Optional["MissingLinksTracker"] = None,
-) -> None:
+) -> int:
     from esgvoc.core.service.resolver_config import ResolverConfig
 
     data_descriptor_id = data_descriptor_path.name
@@ -110,6 +119,7 @@ def ingest_data_descriptor(
         # We ll know it only when we ll add a term (hypothesis all term have the same kind in a data_descriptor)
         data_descriptor = UDataDescriptor(id=data_descriptor_id, context=context, term_kind="")
         term_kind_dd = None
+        error_count = 0
 
         _LOGGER.debug(f"add data_descriptor : {data_descriptor_id}")
         for term_file_path in data_descriptor_path.iterdir():
@@ -154,6 +164,7 @@ def ingest_data_descriptor(
                         f"   Error Message: {str(e)}\n"
                         f"   Full Traceback:\n{traceback.format_exc()}"
                     )
+                    error_count += 1
                     continue
                 if term_id and json_specs and data_descriptor and term_kind:
                     _LOGGER.debug(f"adding {term_id}")
@@ -176,6 +187,7 @@ def ingest_data_descriptor(
             data_descriptor.term_kind = TermKind.PLAIN
         session.add(data_descriptor)
         session.commit()
+        return error_count
 
 
 def get_universe_term(data_descriptor_id: str, term_id: str, universe_db_session: Session) -> tuple[TermKind, dict]:

--- a/tests/admin_build_db/test_builder.py
+++ b/tests/admin_build_db/test_builder.py
@@ -497,6 +497,7 @@ class TestBuildUniverseOrchestration:
 
         def _fake_build_universe_db(universe_path, universe_db, universe_sha):
             _make_sqlite(universe_db)
+            return 0
 
         with patch.object(builder, "_clone"), \
              patch.object(builder, "_build_universe_db", side_effect=_fake_build_universe_db):
@@ -516,6 +517,7 @@ class TestBuildUniverseOrchestration:
 
         def _fake_build_universe_db(universe_path, universe_db, universe_sha):
             _make_sqlite(universe_db)
+            return 0
 
         with patch.object(builder, "_clone") as mock_clone, \
              patch.object(builder, "_build_universe_db", side_effect=_fake_build_universe_db):
@@ -532,6 +534,7 @@ class TestBuildUniverseOrchestration:
 
         def _fake_build_universe_db(universe_path, universe_db, universe_sha):
             _make_sqlite(universe_db)
+            return 0
 
         with patch.object(builder, "_clone"), \
              patch.object(builder, "_build_universe_db", side_effect=_fake_build_universe_db):
@@ -554,6 +557,7 @@ class TestBuildUniverseOrchestration:
 
         def _fake_build_universe_db(universe_path, universe_db, universe_sha):
             _make_sqlite(universe_db)
+            return 0
 
         with patch.object(builder, "_clone"), \
              patch.object(builder, "_build_universe_db", side_effect=_fake_build_universe_db):
@@ -580,9 +584,11 @@ class TestRunBuildManifestOverrides:
 
         def _fake_universe_db(universe_path, universe_db, universe_sha):
             _make_sqlite(universe_db)
+            return 0
 
         def _fake_project_db(project_path, universe_path, universe_db, project_db, project_sha):
             _make_sqlite(project_db)
+            return 0
 
         with patch.object(builder, "_build_universe_db", side_effect=_fake_universe_db), \
              patch.object(builder, "_build_project_db", side_effect=_fake_project_db):
@@ -617,9 +623,11 @@ class TestRunBuildManifestOverrides:
 
         def _fake_universe_db(universe_path, universe_db, universe_sha):
             _make_sqlite(universe_db)
+            return 0
 
         def _fake_project_db(project_path, universe_path, universe_db, project_db, project_sha):
             _make_sqlite(project_db)
+            return 0
 
         with patch.object(builder, "_build_universe_db", side_effect=_fake_universe_db), \
              patch.object(builder, "_build_project_db", side_effect=_fake_project_db):
@@ -697,7 +705,7 @@ class TestMissingLinksTrackerPaths:
              patch("esgvoc.core.db.models.universe.universe_create_db"), \
              patch("esgvoc.core.db.connection.DBConnection"), \
              patch("esgvoc.core.db.universe_ingestion.ingest_metadata_universe"), \
-             patch("esgvoc.core.db.universe_ingestion.ingest_universe"):
+             patch("esgvoc.core.db.universe_ingestion.ingest_universe", return_value=0):
             with pytest.raises(RuntimeError, match="missing links sentinel"):
                 builder._build_universe_db(tmp_path, universe_db, "abc123")
 
@@ -719,7 +727,7 @@ class TestMissingLinksTrackerPaths:
 
         with patch("esgvoc.admin.builder.MissingLinksTracker", return_value=mock_tracker), \
              patch("esgvoc.core.db.models.project.project_create_db"), \
-             patch("esgvoc.core.db.project_ingestion.ingest_project"):
+             patch("esgvoc.core.db.project_ingestion.ingest_project", return_value=0):
             with pytest.raises(RuntimeError, match="missing links sentinel"):
                 builder._build_project_db(
                     project_path=tmp_path,
@@ -742,8 +750,143 @@ class TestMissingLinksTrackerPaths:
              patch("esgvoc.core.db.models.universe.universe_create_db"), \
              patch("esgvoc.core.db.connection.DBConnection"), \
              patch("esgvoc.core.db.universe_ingestion.ingest_metadata_universe"), \
-             patch("esgvoc.core.db.universe_ingestion.ingest_universe"):
-            builder._build_universe_db(tmp_path, universe_db, None)
+             patch("esgvoc.core.db.universe_ingestion.ingest_universe", return_value=0):
+            result = builder._build_universe_db(tmp_path, universe_db, None)
+        assert result == 0
 
         # MissingLinksTracker should never be instantiated when flag is False
         MockTracker.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Ingestion error tracking — error counts propagate to metadata & BuildResult
+# ---------------------------------------------------------------------------
+
+class TestIngestionErrorTracking:
+
+    def test_run_build_stores_zero_errors_in_metadata(self, tmp_path):
+        builder = DBBuilder(work_dir=tmp_path, verbose=False)
+        output = tmp_path / "out.db"
+
+        def _fake_universe_db(universe_path, universe_db, universe_sha):
+            _make_sqlite(universe_db)
+            return 0
+
+        def _fake_project_db(project_path, universe_path, universe_db, project_db, project_sha):
+            _make_sqlite(project_db)
+            return 0
+
+        with patch.object(builder, "_build_universe_db", side_effect=_fake_universe_db), \
+             patch.object(builder, "_build_project_db", side_effect=_fake_project_db):
+            builder._run_build(
+                project_path=tmp_path,
+                universe_path=tmp_path,
+                project_sha="aaa",
+                universe_sha="bbb",
+                output_path=output,
+                tmp=tmp_path,
+                manifest_overrides={"project_id": "test", "cv_version": "1.0"},
+            )
+
+        conn = sqlite3.connect(str(output))
+        rows = dict(conn.execute("SELECT key, value FROM _esgvoc_metadata").fetchall())
+        conn.close()
+        assert rows["ingestion_errors"] == "0"
+
+    def test_run_build_stores_nonzero_errors_in_metadata(self, tmp_path):
+        builder = DBBuilder(work_dir=tmp_path, verbose=False)
+        output = tmp_path / "out.db"
+
+        def _fake_universe_db(universe_path, universe_db, universe_sha):
+            _make_sqlite(universe_db)
+            return 3
+
+        def _fake_project_db(project_path, universe_path, universe_db, project_db, project_sha):
+            _make_sqlite(project_db)
+            return 2
+
+        with patch.object(builder, "_build_universe_db", side_effect=_fake_universe_db), \
+             patch.object(builder, "_build_project_db", side_effect=_fake_project_db):
+            builder._run_build(
+                project_path=tmp_path,
+                universe_path=tmp_path,
+                project_sha="aaa",
+                universe_sha="bbb",
+                output_path=output,
+                tmp=tmp_path,
+                manifest_overrides={"project_id": "test", "cv_version": "1.0"},
+            )
+
+        conn = sqlite3.connect(str(output))
+        rows = dict(conn.execute("SELECT key, value FROM _esgvoc_metadata").fetchall())
+        conn.close()
+        assert rows["ingestion_errors"] == "5"
+
+    def test_build_universe_stores_errors_in_metadata(self, tmp_path):
+        builder = DBBuilder(work_dir=tmp_path / "work", verbose=False)
+        output = tmp_path / "universe.db"
+
+        def _fake_build_universe_db(universe_path, universe_db, universe_sha):
+            _make_sqlite(universe_db)
+            return 7
+
+        with patch.object(builder, "_clone"), \
+             patch.object(builder, "_build_universe_db", side_effect=_fake_build_universe_db):
+            builder.build_universe(
+                universe_repo="WCRP-CMIP/WCRP-universe",
+                universe_ref="main",
+                output_path=output,
+            )
+
+        conn = sqlite3.connect(str(output))
+        rows = dict(conn.execute("SELECT key, value FROM _esgvoc_metadata").fetchall())
+        conn.close()
+        assert rows["ingestion_errors"] == "7"
+
+    def test_build_universe_db_returns_error_count(self, tmp_path):
+        builder = DBBuilder(fail_on_missing_links=False, verbose=False)
+        universe_db = tmp_path / "universe.db"
+
+        with patch("esgvoc.core.db.models.universe.universe_create_db"), \
+             patch("esgvoc.core.db.connection.DBConnection"), \
+             patch("esgvoc.core.db.universe_ingestion.ingest_metadata_universe"), \
+             patch("esgvoc.core.db.universe_ingestion.ingest_universe", return_value=5):
+            result = builder._build_universe_db(tmp_path, universe_db, "sha")
+        assert result == 5
+
+    def test_build_project_db_returns_error_count(self, tmp_path):
+        builder = DBBuilder(fail_on_missing_links=False, verbose=False)
+        universe_db = tmp_path / "universe.db"
+        project_db = tmp_path / "project.db"
+        _make_sqlite(universe_db)
+
+        with patch("esgvoc.core.db.models.project.project_create_db"), \
+             patch("esgvoc.core.db.project_ingestion.ingest_project", return_value=4):
+            result = builder._build_project_db(
+                project_path=tmp_path,
+                universe_path=tmp_path,
+                universe_db=universe_db,
+                project_db=project_db,
+                project_sha="sha",
+            )
+        assert result == 4
+
+    def test_release_notes_in_build_result(self, tmp_path):
+        result = BuildResult(
+            output_path=tmp_path / "test.db",
+            project_id="test",
+            cv_version="1.0",
+            universe_version="1.0",
+            commit_sha="abc",
+            universe_commit_sha="def",
+            build_date=datetime.now(timezone.utc),
+            esgvoc_version="0.1.0",
+            checksum_sha256="a" * 64,
+            size_bytes=1024,
+            release_notes="Initial release",
+        )
+        assert result.release_notes == "Initial release"
+
+    def test_release_notes_defaults_to_none(self, tmp_path):
+        result = _fake_result(tmp_path)
+        assert result.release_notes is None

--- a/tests/admin_build_db/test_validator.py
+++ b/tests/admin_build_db/test_validator.py
@@ -1,0 +1,291 @@
+"""
+Tests for DBValidator — validating pre-built database artifacts.
+
+Unit tests use minimal SQLite files with injected metadata — no real CV repos needed.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from esgvoc.admin.validator import DBValidator, ValidationResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db(path: Path, metadata: dict | None = None, tables: dict[str, int] | None = None) -> Path:
+    """Create a minimal SQLite DB with optional metadata and table stubs."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS _esgvoc_metadata (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    if metadata:
+        for k, v in metadata.items():
+            conn.execute(
+                "INSERT OR REPLACE INTO _esgvoc_metadata (key, value) VALUES (?, ?)",
+                (k, v),
+            )
+    if tables:
+        for table_name, row_count in tables.items():
+            conn.execute(f"CREATE TABLE IF NOT EXISTS {table_name} (id TEXT)")
+            for i in range(row_count):
+                conn.execute(f"INSERT INTO {table_name} (id) VALUES (?)", (f"row_{i}",))
+    conn.commit()
+    conn.close()
+    return path
+
+
+_BASE_META = {
+    "project_id": "testproject",
+    "cv_version": "1.0.0",
+    "build_date": "2025-01-01T00:00:00+00:00",
+    "esgvoc_version": "4.0.1",
+}
+
+_UNIVERSE_META = {
+    "project_id": "universe",
+    "cv_version": "1.0.0",
+    "build_date": "2025-01-01T00:00:00+00:00",
+    "esgvoc_version": "4.0.1",
+}
+
+
+# ---------------------------------------------------------------------------
+# ValidationResult
+# ---------------------------------------------------------------------------
+
+class TestValidationResult:
+
+    def test_starts_passed(self):
+        r = ValidationResult()
+        assert r.passed
+
+    def test_add_ok_stays_passed(self):
+        r = ValidationResult()
+        r.add("check1", True, "good")
+        assert r.passed
+
+    def test_add_fail_sets_failed(self):
+        r = ValidationResult()
+        r.add("check1", False, "bad")
+        assert not r.passed
+
+    def test_summary_contains_check_names(self):
+        r = ValidationResult()
+        r.add("alpha", True, "ok")
+        r.add("beta", False, "nope")
+        s = r.summary()
+        assert "alpha" in s
+        assert "beta" in s
+        assert "FAILED" in s
+
+    def test_summary_passed_when_all_ok(self):
+        r = ValidationResult()
+        r.add("only_check", True)
+        assert "PASSED" in r.summary()
+
+
+# ---------------------------------------------------------------------------
+# DBValidator.validate — basic checks
+# ---------------------------------------------------------------------------
+
+class TestValidateBasic:
+
+    def test_missing_file_fails(self, tmp_path):
+        v = DBValidator()
+        result = v.validate(tmp_path / "nonexistent.db")
+        assert not result.passed
+
+    def test_non_sqlite_file_fails(self, tmp_path):
+        bad = tmp_path / "bad.db"
+        bad.write_text("not a sqlite file")
+        v = DBValidator()
+        result = v.validate(bad)
+        assert not result.passed
+
+    def test_valid_project_db_passes(self, tmp_path):
+        db = _make_db(
+            tmp_path / "test.db",
+            metadata=_BASE_META,
+            tables={"pcollections": 2, "pterms": 5},
+        )
+        v = DBValidator()
+        with patch.object(DBValidator, "_check_all_terms_via_api"):
+            result = v.validate(db)
+        assert result.passed
+
+    def test_valid_universe_db_passes(self, tmp_path):
+        db = _make_db(
+            tmp_path / "universe.db",
+            metadata=_UNIVERSE_META,
+            tables={"universes": 1, "udata_descriptors": 3, "uterms": 10},
+        )
+        v = DBValidator()
+        with patch.object(DBValidator, "_check_all_terms_via_api"):
+            result = v.validate(db)
+        assert result.passed
+
+    def test_missing_metadata_key_fails(self, tmp_path):
+        incomplete_meta = {k: v for k, v in _BASE_META.items() if k != "cv_version"}
+        db = _make_db(
+            tmp_path / "test.db",
+            metadata=incomplete_meta,
+            tables={"pcollections": 1, "pterms": 1},
+        )
+        v = DBValidator()
+        with patch.object(DBValidator, "_check_all_terms_via_api"):
+            result = v.validate(db)
+        assert not result.passed
+
+    def test_empty_table_fails(self, tmp_path):
+        db = _make_db(
+            tmp_path / "test.db",
+            metadata=_BASE_META,
+            tables={"pcollections": 0, "pterms": 5},
+        )
+        v = DBValidator()
+        with patch.object(DBValidator, "_check_all_terms_via_api"):
+            result = v.validate(db)
+        assert not result.passed
+
+
+# ---------------------------------------------------------------------------
+# DBValidator.validate — ingestion_errors metadata check
+# ---------------------------------------------------------------------------
+
+class TestIngestionErrorsCheck:
+
+    def test_zero_errors_passes(self, tmp_path):
+        meta = {**_BASE_META, "ingestion_errors": "0"}
+        db = _make_db(tmp_path / "test.db", metadata=meta, tables={"pcollections": 1, "pterms": 1})
+        v = DBValidator()
+        with patch.object(DBValidator, "_check_all_terms_via_api"):
+            result = v.validate(db)
+        assert result.passed
+        check_names = [c[0] for c in result.checks]
+        assert "ingestion_errors" in check_names
+
+    def test_nonzero_errors_fails(self, tmp_path):
+        meta = {**_BASE_META, "ingestion_errors": "3"}
+        db = _make_db(tmp_path / "test.db", metadata=meta, tables={"pcollections": 1, "pterms": 1})
+        v = DBValidator()
+        with patch.object(DBValidator, "_check_all_terms_via_api"):
+            result = v.validate(db)
+        assert not result.passed
+        err_check = [c for c in result.checks if c[0] == "ingestion_errors"]
+        assert len(err_check) == 1
+        assert not err_check[0][1]  # failed
+        assert "3 term(s) failed" in err_check[0][2]
+
+    def test_missing_ingestion_errors_key_is_ok(self, tmp_path):
+        """If the key is absent (older DB), skip the check — don't fail."""
+        db = _make_db(tmp_path / "test.db", metadata=_BASE_META, tables={"pcollections": 1, "pterms": 1})
+        v = DBValidator()
+        with patch.object(DBValidator, "_check_all_terms_via_api"):
+            result = v.validate(db)
+        assert result.passed
+        check_names = [c[0] for c in result.checks]
+        assert "ingestion_errors" not in check_names
+
+
+# ---------------------------------------------------------------------------
+# DBValidator._check_all_terms_via_api
+# ---------------------------------------------------------------------------
+
+class TestCheckAllTermsViaApi:
+
+    def _run(self, tmp_path, project_id, result, *, is_universe=False,
+             previous_active=None, collections=None, terms_side_effect=None,
+             universe_terms=None):
+        """Helper to run _check_all_terms_via_api with mocked UserState + API."""
+        db = _make_db(tmp_path / "test.db")
+        mock_state = MagicMock()
+        mock_state.get_active.return_value = previous_active
+
+        mock_user_state_cls = MagicMock()
+        mock_user_state_cls.load.return_value = mock_state
+        mock_user_state_cls.db_path.return_value = tmp_path / "dbs" / project_id / "_validate_temp.db"
+
+        patches = [
+            patch("esgvoc.core.service.user_state.UserState", mock_user_state_cls),
+        ]
+        if is_universe:
+            patches.append(patch("esgvoc.api.get_all_terms_in_universe", return_value=universe_terms or []))
+        else:
+            patches.append(patch("esgvoc.api.get_all_collections_in_project", return_value=collections or []))
+            if terms_side_effect is not None:
+                patches.append(patch("esgvoc.api.get_all_terms_in_collection", side_effect=terms_side_effect))
+
+        for p in patches:
+            p.start()
+        try:
+            DBValidator._check_all_terms_via_api(db, project_id, result, is_universe=is_universe)
+        finally:
+            for p in patches:
+                p.stop()
+
+        return mock_state
+
+    def test_project_all_collections_ok(self, tmp_path):
+        result = ValidationResult()
+        self._run(
+            tmp_path, "testproject", result,
+            collections=["coll_a", "coll_b"],
+            terms_side_effect=[
+                [MagicMock(), MagicMock()],  # coll_a: 2 terms
+                [MagicMock()],               # coll_b: 1 term
+            ],
+        )
+        assert result.passed
+        api_check = [c for c in result.checks if c[0] == "API term instantiation"]
+        assert len(api_check) == 1
+        assert "3 terms across 2 collections" in api_check[0][2]
+
+    def test_project_collection_failure(self, tmp_path):
+        result = ValidationResult()
+        self._run(
+            tmp_path, "testproject", result,
+            collections=["good", "bad"],
+            terms_side_effect=[
+                [MagicMock()],
+                RuntimeError("parse error"),
+            ],
+        )
+        assert not result.passed
+        api_check = [c for c in result.checks if c[0] == "API term instantiation"]
+        assert "1 collection(s) failed" in api_check[0][2]
+
+    def test_universe_terms_ok(self, tmp_path):
+        result = ValidationResult()
+        self._run(
+            tmp_path, "universe", result,
+            is_universe=True,
+            universe_terms=[MagicMock()] * 50,
+        )
+        assert result.passed
+        api_check = [c for c in result.checks if c[0] == "API term instantiation"]
+        assert "50 universe terms OK" in api_check[0][2]
+
+    def test_restores_previous_active_state(self, tmp_path):
+        result = ValidationResult()
+        mock_state = self._run(
+            tmp_path, "proj", result,
+            previous_active="v1.0.0",
+            collections=[],
+        )
+        # Should restore the previous active version
+        mock_state.set_active.assert_called_with("proj", "v1.0.0", source="local")
+
+    def test_removes_active_if_none_previously(self, tmp_path):
+        result = ValidationResult()
+        mock_state = self._run(
+            tmp_path, "proj", result,
+            previous_active=None,
+            collections=[],
+        )
+        mock_state.remove_active.assert_called_once_with("proj")

--- a/tests/python_api/test_projects_api.py
+++ b/tests/python_api/test_projects_api.py
@@ -390,7 +390,10 @@ class TestValidTermFull:
         import esgvoc.api.projects as projects
 
         result = projects.valid_term_in_all_projects("this_value_certainly_does_not_match_xyz_123")
-        assert result == []
+        # Freetext pattern terms (regex ".*") legitimately match any value,
+        # so only assert that non-freetext terms are absent.
+        non_freetext = [m for m in result if m.term_id != "freetext"]
+        assert non_freetext == []
 
 
 class TestValidTermInCollection:


### PR DESCRIPTION
- **Builder: CV manifest support** — `DBBuilder` now loads `esgvoc_manifest.yaml` from repos to populate `cv_version`,
  `esgvoc_min_version`, and `release_notes` in build metadata and `BuildResult`
 - **Ingestion error tracking** — `ingest_universe` / `ingest_project` return error counts; errors are stored in DB
  metadata (`ingestion_errors`) and surfaced by the validator
 - **Validator: full API term instantiation** — `DBValidator.validate()` now temporarily installs the DB and instantiates
  every term through the public API to catch deserialization issues
 - **CLI `use`: multiple specs** — `esgvoc use` now accepts multiple project specs in one command (e.g. `esgvoc use
  cmip7@1.1.0 universe@latest`)
 - **CLI `use`: version regex fix** — registry pattern now accepts versions with or without the `v` prefix
 - **JSON schema generator** — adds `maxLength: 1064` constraint to free-text string properties (no `source_collection`)
 - **`project_specs`: backward-compat alias** — `AttributeProperty.field_name` property returns `attr_field_name` for
  legacy consumers
 - **CLI `test-cv`: full coverage** — `_api_smoke_test` now instantiates all terms in all collections instead of
  spot-checking 5
 - **Schema version** — add `get_schema_version` utility